### PR TITLE
feat: get custom result for css modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,11 @@
     "webpack": "^4.4.0"
   },
   "dependencies": {
-    "loader-utils": "^1.1.0",
+    "cssesc": "3.0.0",
+    "loader-utils": "1.4.0",
+    "normalize-path": "3.0.0",
     "normalize-url": "1.9.1",
+    "postcss": "^7.0.35",
     "schema-utils": "^1.0.0",
     "webpack-sources": "^1.1.0"
   },

--- a/src/css-modules.js
+++ b/src/css-modules.js
@@ -1,0 +1,81 @@
+import path from 'path';
+
+import postcss from 'postcss';
+import { interpolateName } from 'loader-utils';
+import normalizePath from 'normalize-path';
+import cssesc from 'cssesc';
+
+// Source: https://github.com/webpack-contrib/css-loader/blob/v3.5.2/src/utils.js
+
+// eslint-disable-next-line no-control-regex
+const filenameReservedRegex = /[<>:"/\\|?*\x00-\x1F]/g;
+// eslint-disable-next-line no-control-regex
+const reControlChars = /[\u0000-\u001f\u0080-\u009f]/g;
+const reRelativePath = /^\.+/;
+
+function getLocalIdent(loaderContext, localIdentName) {
+  const options = {
+    context: loaderContext.rootContext,
+    content: '',
+    hashPrefix: '',
+    regExp: null,
+  };
+
+  const request = normalizePath(
+    path.relative(options.context || '', loaderContext.resourcePath)
+  );
+
+  // eslint-disable-next-line no-param-reassign
+  options.content = `${options.hashPrefix + request}`;
+
+  // Using `[path]` placeholder outputs `/` we need escape their
+  // Also directories can contains invalid characters for css we need escape their too
+  return cssesc(
+    interpolateName(loaderContext, localIdentName, options)
+      // For `[hash]` placeholder
+      .replace(/^((-?[0-9])|--)/, '_$1')
+      .replace(filenameReservedRegex, '-')
+      .replace(reControlChars, '-')
+      .replace(reRelativePath, '-')
+      .replace(/\./g, '-'),
+    { isIdentifier: true }
+  ).replace(/\\\[local\\\]/gi, '');
+}
+
+const CSS_MODULES_REGEX = new RegExp(/\.module\.scss$/);
+const LOCAL_IDENT_NAME = '[hash:base64:10]';
+
+function isCSSModulesFile(loaderContext) {
+  const request = normalizePath(
+    path.relative(loaderContext.rootContext || '', loaderContext.resourcePath)
+  );
+
+  return CSS_MODULES_REGEX.test(request);
+}
+
+function getCustomResult(loaderContext, text, locals) {
+  const cssContent = text.length > 0 ? text[0].content || '' : '';
+  const cssRoot = postcss.parse(cssContent);
+  const cssRules = new Set();
+
+  cssRoot.walkRules(function(rule) {
+    if (rule.parent.type === 'atrule') {
+      cssRules.add(rule.parent.toString());
+    } else {
+      cssRules.add(rule.toString());
+    }
+  });
+
+  const fileId = getLocalIdent(loaderContext, LOCAL_IDENT_NAME);
+  let result = '';
+
+  result = `\nmodule.exports = ${JSON.stringify(locals)};`;
+  result += `\nmodule.exports.__css__ = ${JSON.stringify(
+    Array.from(cssRules)
+  )};`;
+  result += `\nmodule.exports.__id__ = "${fileId}";`;
+
+  return result;
+}
+
+export { isCSSModulesFile, getCustomResult };


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Get custom properties for CSS Modules:
- `__css__`: CSS Modules file code
- `__id__`: A unique id of CSS Modules

And restrict CSS Modules code from getting extracted.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
